### PR TITLE
Fix Typo in Page Title: Elemint → Element

### DIFF
--- a/frontend/src/pages/AI/index.tsx
+++ b/frontend/src/pages/AI/index.tsx
@@ -48,7 +48,7 @@ export default function LayoutWithSidebar() {
 
 	return (
 		<div className='mobile-safe-container flex overflow-hidden bg-secondary'>
-			<Head title={curItem.name ?? 'Create a new Elemint'} />
+			<Head title={curItem.name ?? 'Create a new Element'} />
 			<Register />
 			<div
 				className={cn(


### PR DESCRIPTION
This pull request fixes a minor typo in the page title, changing "Elemint" to "Element" in index.tsx. This correction ensures consistency and accuracy in the user interface.
