### PR TITLE
Gitpodify - Add support to launch Open UI in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,7 @@ tasks:
     command: |
       source $GITPOD_REPO_ROOT/../venv/openui/bin/activate
       cd $GITPOD_REPO_ROOT/backend
-      python -m venv openui
+      python -m openui
 
 # List the ports to expose. Learn more: https://www.gitpod.io/docs/configure/workspaces/ports
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,27 @@
+# Image of workspace. Learn more: https://www.gitpod.io/docs/configure/workspaces/workspace-image
+image: gitpod/workspace-full:latest
+
+# List the start up tasks. Learn more: https://www.gitpod.io/docs/configure/workspaces/tasks
+tasks:
+  - name: Run Open UI
+    init: |
+      mkdir $GITPOD_REPO_ROOT/../venv
+      cd $GITPOD_REPO_ROOT/../venv
+      python -m venv openui
+      source openui/bin/activate
+      cd $GITPOD_REPO_ROOT/backend
+      pip install .
+      gp sync-done init-done
+    command: |
+      source $GITPOD_REPO_ROOT/../venv/openui/bin/activate
+      cd $GITPOD_REPO_ROOT/backend
+      python -m venv openui
+
+# List the ports to expose. Learn more: https://www.gitpod.io/docs/configure/workspaces/ports
+ports:
+  - name: Open UI
+    description: Port 7878 for Open UI
+    port: 7878
+    onOpen: notify
+
+# Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ The codespace installs ollama automaticaly and downloads the `llava` model.  You
 
 <img src="./assets/ollama.png" width="500" alt="Select Ollama models" />
 
+### Gitpod
+
+You can easily use Open UI via Gitpod, preconfigured with Open AI.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/wandb/openui)
+
+On launch Open UI is automatically installed and launched.
+
+Before you can use Gitpod:
+
+* Make sure you have a Gitpod account.
+* To use Open AI models set up the `OPENAI_API_KEY` environment variable in your Gitpod [User Account](https://gitpod.io/user/variables). Set the scope to `wandb/openui` (or your repo if you forked it).
+
+> NOTE: Other (local) models might also be used with a bigger Gitpod instance type. Required models are not preconfigured in Gitpod but can easily be added as documented above.
 
 ### Resources
 


### PR DESCRIPTION
With this PR I want to suggest adding Gitpod support. Gitpod is an online dev environment and browser based IDE (similar to Github Codespaces with some additional features).

The PR contains the following changes:

* I added a simple `.gitpod.yml` that defines how the Gitpod container should be started.
  * On workspace initialization it sets up an Open UI python virtual environment.
  * Installs backend dependencies with pip as described in the README.
  * It starts the Open UI backend, ready to use if `OPENAI_API_KEY` is provided.
* I added a Gitpod section in the README with an "Open in Gitpod" button.

To use Gitpod a user needs a (free) Gitpod account. To use the Open AI API, the `OPENAI_API_KEY` must be provided as an environment variable as described in the README.

I did not set up Ollama by default, since the default Gitpod containers are not too powerful. I didn't try it. Do you think this should be added or should we provide some simple script to automate the setup in Gitpod? We could also set it up but not launch it. So it's ready to go.

What do you think about this PR? What should be improved?