### PR TITLE
Preventing clicking on hidden example buttons on AI prompt pages.

### DIFF
--- a/frontend/src/pages/AI/Builder.tsx
+++ b/frontend/src/pages/AI/Builder.tsx
@@ -438,7 +438,7 @@ export default function Builder({ isShared }: { isShared?: boolean }) {
 						<Examples
 							className={cn(
 								'absolute left-[calc(50%)] w-11/12 -translate-x-1/2',
-								llmHidden && '-bottom-10 opacity-0'
+								llmHidden && '-bottom-10 opacity-0 pointer-events-none'
 							)}
 							style={{
 								bottom: bigEnough ? '130px' : '230px'


### PR DESCRIPTION
I found a bug in the AI prompt page.
I can still click the prompt example buttons even if that is hidden and set by opacity zero.
So, I fixed that by adding the 'pointer-events-none' class.