### PR TITLE
fix: scrollbar visible at all time

### DIFF
--- a/frontend/src/components/CodeViewer.tsx
+++ b/frontend/src/components/CodeViewer.tsx
@@ -113,7 +113,7 @@ export default function CodeViewer({ id, code }: ViewerProps) {
 		<div className='code-syntax-wrapper'>
 			<div className='code-syntax relative rounded-lg border'>
 				<div className='grid w-full grid-cols-4 rounded-t-md border-b'>
-					<ul className='z-10 col-span-3 flex max-h-9 w-full overflow-y-hidden overflow-x-scroll rounded-tl-lg bg-background text-center text-sm font-medium text-gray-500 dark:text-gray-400'>
+					<ul className='z-10 col-span-3 flex max-h-9 w-full overflow-y-hidden overflow-x-auto rounded-tl-lg bg-background text-center text-sm font-medium text-gray-500 dark:text-gray-400'>
 						{frameworks.map((f, i) => (
 							<li key={f}>
 								<button


### PR DESCRIPTION
Fixes the scrollbar showing up all the time. Currently it's always visible even when there's no x overflow

![image](https://github.com/user-attachments/assets/3581090d-5e91-4ae0-9136-b3a0cd433b2c)
