### PR TITLE
Allow changing the port with --port flag

### DIFF
--- a/backend/openui/__main__.py
+++ b/backend/openui/__main__.py
@@ -38,6 +38,12 @@ if __name__ == "__main__":
         or "OPENUI_LITELLM_CONFIG" in os.environ
         or os.path.exists("litellm-config.yaml")
     )
+    # allow setting the port with --port
+    port = (
+        int(sys.argv[sys.argv.index("--port") + 1])
+        if "--port" in sys.argv and len(sys.argv) > sys.argv.index("--port") + 1
+        else None
+    ) or int(os.environ.get("PORT", 7878))
     # TODO: only render in interactive mode?
     print(
         (Path(__file__).parent / "logo.ascii").read_text(), file=sys.stderr, flush=True
@@ -68,7 +74,7 @@ if __name__ == "__main__":
             "openui.server:app",
             host="0.0.0.0" if is_running_in_docker() else "127.0.0.1",
             log_config=str(config_file) if ui else None,
-            port=7878,
+            port=port,
             reload=reload,
         )
     )
@@ -111,7 +117,7 @@ if __name__ == "__main__":
             uvicorn.run(
                 "openui.server:app",
                 host="0.0.0.0" if is_running_in_docker() else "127.0.0.1",
-                port=7878,
+                port=port,
                 reload=reload,
             )
         else:


### PR DESCRIPTION
I wanted to run openui on my home lab but I'm using the default port for another service, so I added the ability to configure the port with the `--port` flag. It defaults to 7878. Here an example of using it. Also allows you to set the port using the environment variable `PORT`.

```sh
$ docker run --rm --name openui -p 8989:8989 -e OPENAI_API_KEY -e ANTHROPIC_API_KEY -e OLLAMA_HOST=http://host.docker.internal:11434 openui --port 8989
                                                         
         __g@@@@@@gg__            _~@@    @@@@@@@@@@@@@@@
      _@@@@@@@@@@@@@@@@g_      _@@@@@@@,  @@@@@@@@@@@@@@@
    o@@@@@@@@@@@@@@@@@@@@@ _g@@@@@@@@@@@L @@@@@@@@@@@@@@@
  ,@@@@@@@@@@@@@@@@@@@B"~@@@@@@@@@@@@@@@@a%@@@@@@@@@@@@@@
 ,""""""""""""""""""_g@@@@@@@@@@@@@@@@@@@@g\@@@@@@@@@@@@@
 @@@@@@@@@@@@@@P"~?????????????????????????? gggggggggggg
!@@@@@@@@@@@@@@,=============================|@@@@@@@@@@@
[@@@@@@@@@@@@@@@L"""""""""""""""""""""""""""" @@@@@@@@@@@
 BBBBBBBBBBBBBBBBh<========================== @@@@@@@@@@@
 vggggggggggggggggg ggggggggggggggggggggggggg,@@@@@@@@@@@
  %@@@@@@@@@@@@@@@@@'@@@@@@@@@@@@@@@@@@@@@@@'@@@@@@@@@@@@
   "@@@@@@@@@@@@@@@@@LQ@@@@@@@@@@@@@@@@@@@@,@@@@@@@@@@@@@
     "@@@@@@@@@@@@@@@@@'@@@@@@@@@@@@@@@@@Po@@@@@@@@@@@@@@
        "4@@@@@@@@@@@P"   """""""""""""   @@@@@@@@@@@@@@@
                                                         
                                                         

INFO (openui):  Starting OpenUI AI Server created by W&B...
INFO (openui):  Starting LiteLLM in the background with config: /tmp/tmp7a2jx8b0.yaml
INFO (openui):  Running API Server
INFO (uvicorn.error):  Started server process [1]
INFO (uvicorn.error):  Waiting for application startup.
DEBUG (openui):  Starting up server in 1...
INFO (uvicorn.error):  Application startup complete.
INFO (uvicorn.error):  Uvicorn running on http://0.0.0.0:8989 (Press CTRL+C to quit)
```

Enhancements to port configuration:

* [`backend/openui/__main__.py`](diffhunk://#diff-8ac013740194dbc1ef7c74d0344c07fe6df7f0bb62923169538fcfeb8be15d97R41-R46): Added logic to parse the port number from the command-line argument `--port` if provided, or fallback to the `PORT` environment variable, defaulting to 7878 if neither is specified.
* [`backend/openui/__main__.py`](diffhunk://#diff-8ac013740194dbc1ef7c74d0344c07fe6df7f0bb62923169538fcfeb8be15d97L71-R77): Updated the `uvicorn.run` calls to use the dynamically determined port instead of the hardcoded value 7878. [[1]](diffhunk://#diff-8ac013740194dbc1ef7c74d0344c07fe6df7f0bb62923169538fcfeb8be15d97L71-R77) [[2]](diffhunk://#diff-8ac013740194dbc1ef7c74d0344c07fe6df7f0bb62923169538fcfeb8be15d97L114-R120)