### PR TITLE
Implement respondToToolCalls

### DIFF
--- a/frontend/src/api/openai.ts
+++ b/frontend/src/api/openai.ts
@@ -223,6 +223,57 @@ function processToolCalls(
 	return toolCallAccumulator
 }
 
+function postToolCallsToIframe(
+	iframeId: string,
+	toolCalls: Record<
+		number,
+		OpenAI.Chat.Completions.ChatCompletionMessageToolCall
+	>
+) {
+	const iframe = document.getElementById(
+		`iframe-${iframeId}`
+	) as HTMLIFrameElement
+	const iframeWindow = iframe?.contentWindow
+	if (!iframeWindow) {
+		console.error('No iframe found', iframeId)
+		return
+	}
+	for (const toolCall of Object.values(toolCalls)) {
+		if (toolCall.function.name === 'exec-script') {
+			const { javascript, description } = JSON.parse(
+				toolCall.function.arguments
+			)
+			iframeWindow.postMessage(
+				{
+					action: 'exec-script',
+					id: iframeId,
+					toolCallId: toolCall.id,
+					javascript,
+					description
+				},
+				'*'
+			)
+		} else if (toolCall.function.name === 'edit') {
+			const { mode, selector, html, description, multiple } = JSON.parse(
+				toolCall.function.arguments
+			)
+			iframeWindow.postMessage(
+				{
+					action: 'edit',
+					id: iframeId,
+					toolCallId: toolCall.id,
+					mode,
+					selector,
+					html,
+					description,
+					multiple
+				},
+				'*'
+			)
+		}
+	}
+}
+
 type Response = {
 	body: string
 	toolCalls: Record<
@@ -232,16 +283,53 @@ type Response = {
 }
 
 export async function respondToToolCalls(
-	ctx: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	ctx: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming & {
+		iframeId?: string
+	},
 	toolCalls: ToolFinishEvent[],
-	sessionId: string
-) {
-	//ctx.messages.push({})
-	await openai.chat.completions.create(ctx, {
+	sessionId: string,
+	callback: (response: string) => void
+): Promise<Response> {
+	const assistantToolCalls = toolCalls
+		.map(tc => tc.call)
+		.filter(
+			(c): c is OpenAI.Chat.Completions.ChatCompletionMessageToolCall => !!c
+		)
+	if (assistantToolCalls.length > 0) {
+		ctx.messages.push({
+			role: 'assistant',
+			content: '',
+			tool_calls: assistantToolCalls
+		})
+	}
+	for (const tc of toolCalls) {
+		if (tc.call && tc.result) {
+			ctx.messages.push({
+				role: 'tool',
+				tool_call_id: tc.call.id,
+				content: JSON.stringify(tc.result)
+			})
+		}
+	}
+	ctx.stream = true
+	const response = await openai.chat.completions.create(ctx, {
 		headers: {
 			'X-Wandb-Trace-Id': sessionId
 		}
 	})
+	let markdown = ''
+	const finalToolCalls = processToolCalls(undefined, {})
+	for await (const chunk of response) {
+		const part = chunk.choices[0]?.delta?.content ?? ''
+		markdown += part
+		callback(part)
+		processToolCalls(chunk.choices[0]?.delta?.tool_calls, finalToolCalls)
+	}
+	const iframeId = ctx.iframeId
+	if (iframeId) {
+		postToolCallsToIframe(iframeId, finalToolCalls)
+	}
+	return { body: markdown, toolCalls: finalToolCalls }
 }
 
 export async function createOrRefine(
@@ -360,20 +448,25 @@ emoji: 🎉
 	// TODO: use sessionId instead, modify the DOM of jotai dev tools
 	// jotai-devtools-root to include a link to weave
 	console.log('Session ID:', sessionId)
-	const context: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
+	const context: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming & {
+		iframeId: string
+		sessionId: string
+	} = {
 		model,
 		messages,
 		temperature,
 		stream: true,
 		max_tokens: GPT4_MAX_TOKENS,
-		tools
+		tools,
+		iframeId,
+		sessionId: sessionId ?? ''
 	}
 	if (storeContext) {
 		storeContext(context)
 	}
 	const response = await openai.chat.completions.create(context, {
 		headers: {
-			'X-Wandb-Trace-Id': iframeId
+			'X-Wandb-Trace-Id': sessionId
 		}
 	})
 	let markdown = ''
@@ -393,66 +486,8 @@ emoji: 🎉
 		})
 	}
 	console.table(toolTable, ['id', 'name', 'args'])
-	const iframe = document.getElementById(
-		`iframe-${iframeId}`
-	) as HTMLIFrameElement
-	let iframeWindow
-	if (iframe) {
-		iframeWindow = iframe.contentWindow
-	}
-	if (!iframeWindow) {
-		console.error('No iframe found', iframeId)
-		return { body: markdown, toolCalls: finalToolCalls }
-	}
-	// TODO: move these into UI context
-	for (const toolCall of Object.values(finalToolCalls)) {
-		if (toolCall.function.name === 'exec-script') {
-			const { javascript, description } = JSON.parse(
-				toolCall.function.arguments
-			)
-			iframeWindow.postMessage(
-				{
-					action: 'exec-script',
-					id: iframeId,
-					toolCallId: toolCall.id,
-					javascript,
-					description
-				},
-				'*'
-			)
-			console.log(
-				'Sent exec-script to iframe:',
-				javascript,
-				description,
-				iframeId
-			)
-		} else if (toolCall.function.name === 'edit') {
-			const { mode, selector, html, description, multiple } = JSON.parse(
-				toolCall.function.arguments
-			)
-			iframeWindow.postMessage(
-				{
-					action: 'edit',
-					id: iframeId,
-					toolCallId: toolCall.id,
-					mode,
-					selector,
-					html,
-					description,
-					multiple
-				},
-				'*'
-			)
-			console.log(
-				'Sent edit DOM to iframe:',
-				mode,
-				selector,
-				html,
-				description,
-				multiple,
-				iframeId
-			)
-		}
+	if (iframeId) {
+		postToolCallsToIframe(iframeId, finalToolCalls)
 	}
 	return {
 		body: markdown,


### PR DESCRIPTION
## Summary
- implement `respondToToolCalls` to resume conversations after tool calls
- keep iframe and session identifiers in conversation context
- continue tool conversations from `Prompt` component
- reuse shared iframe messaging helper
- use session id for trace headers

## Testing
- `pnpm lint`
- `pnpm test:ci` *(fails: Unable to find role="navigation")*