### PR TITLE
Improve markdown parsing and add Clippy commentary

### DIFF
--- a/frontend/src/components/HtmlAnnotator.tsx
+++ b/frontend/src/components/HtmlAnnotator.tsx
@@ -366,10 +366,18 @@ export default function HTMLAnnotator({ error, id }: HTMLAnnotatorProps) {
 							)}
 							src={`${iframeSrc}/openui/index.html?id=${iframeId}`}
 						/>
-						{/* TODO: redo the scaffold */}
-						{error ? <Scaffold isLoading error={error} /> : undefined}
-					</div>
-				</div>
+                                                {/* TODO: redo the scaffold */}
+                                                {error ? <Scaffold isLoading error={error} /> : undefined}
+                                                {rawItem.commentary && (
+                                                        <div className='pointer-events-none absolute right-2 top-2 flex h-full w-1/3 flex-col items-end'>
+                                                                <div className='pointer-events-auto mb-16 max-h-full overflow-auto whitespace-pre-wrap border border-gray-500 bg-gray-100 p-2 text-xs text-black shadow-lg'>
+                                                                        {rawItem.commentary}
+                                                                </div>
+                                                                <div className='absolute bottom-2 right-2 text-4xl animate-bounce'>📎</div>
+                                                        </div>
+                                                )}
+                                        </div>
+                                </div>
 				<div
 					className={`flex-shrink-0 py-0 pl-4 transition-all duration-500 ease-in-out ${
 						isCodeVisible ? 'sm:w-full md:w-full lg:w-1/2' : 'hidden w-0'

--- a/frontend/src/state/atoms/history.ts
+++ b/frontend/src/state/atoms/history.ts
@@ -39,8 +39,9 @@ export interface HistoryItem {
 	// TODO: Deprecate
 	react?: string
 	components?: FrameworkMap
-	html?: string
-	comments?: string[]
+        html?: string
+        comments?: string[]
+        commentary?: string
 }
 
 interface Chapter {


### PR DESCRIPTION
## Summary
- parse comment text outside HTML fences and expose `commentary` property
- show commentary in HTMLAnnotator using a Clippy styled window
- store commentary in history items

## Testing
- `npm run test:ci` *(fails: Unable to find role="navigation")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6840c6bd769483219adb1fedff385638