### PR TITLE
fix: backend server uncontrolled data used in path expression 

### DIFF
--- a/backend/openui/server.py
+++ b/backend/openui/server.py
@@ -575,10 +575,10 @@ def spa(full_path: str):
     dist_dir = Path(__file__).parent / "dist"
     # TODO: hacky way to only serve index.html on root urls
     files = [entry.name for entry in dist_dir.iterdir() if entry.is_file()]
-    if full_path in files:
-        return FileResponse(dist_dir / full_path)
-    if "." in full_path:
-        raise HTTPException(status_code=404, detail=f"Asset not found: {full_path}")
+    normalized_path = (dist_dir / full_path).resolve()
+    if not normalized_path.is_file() or not str(normalized_path).startswith(str(dist_dir.resolve())):
+        raise HTTPException(status_code=404, detail=f"Asset not found or access denied: {full_path}")
+    return FileResponse(normalized_path)
     return HTMLResponse((dist_dir / "index.html").read_bytes())
 
 


### PR DESCRIPTION
https://github.com/wandb/openui/blob/17764dcdafe83cf2058eb6841f74654775f04f62/backend/openui/server.py#L578-L579

Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.


fix the issue user-supplied `full_path` needs to be validated to ensure it does not lead to directory traversal or access to unintended files. This can be achieved by normalizing the constructed path using `os.path.normpath` and verifying that the resulting path resides within the `dist_dir` directory. This approach ensures that any attempts to traverse directories (e.g., `../`) or use absolute paths are neutralized. Additionally, symbolic link resolution can be handled by using `os.path.realpath`.


[werkzeug.utils.secure_filename](http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)
[CWE-23](https://cwe.mitre.org/data/definitions/23.html)
[CWE-36](https://cwe.mitre.org/data/definitions/36.html)
[CWE-73](https://cwe.mitre.org/data/definitions/73.html)
[CWE-99](https://cwe.mitre.org/data/definitions/99.html)