### PR TITLE
Fix legacy weave type usage in eval models

### DIFF
--- a/backend/openui/eval/evaluate.py
+++ b/backend/openui/eval/evaluate.py
@@ -36,7 +36,6 @@ def data_url(file_path):
 base_dir = Path(__file__).parent / "datasets"
 
 
-@weave.type()
 class EvaluateQualityModel(Model):
     system_message: str
     model_name: str = "gpt-4-vision-preview"
@@ -154,7 +153,7 @@ Output a JSON object with the following structure:
     }
 """
 )
-model = EvaluateQualityModel(SYSTEM_MESSAGE)
+model = EvaluateQualityModel(system_message=SYSTEM_MESSAGE)
 
 
 async def run(row=0, bad=False):

--- a/backend/openui/eval/model.py
+++ b/backend/openui/eval/model.py
@@ -18,7 +18,6 @@ def data_url(file_path):
 base_dir = Path(__file__).parent / "components"
 
 
-@weave.type()
 class EvaluateQualityModel(Model):
     system_message: str
     model_name: str = "gpt-4-vision-preview"


### PR DESCRIPTION
## Summary
- Fixes #211
- Remove legacy `@weave.type()` decorators from eval model classes
- Keep existing `Model` inheritance and `@weave.op()` tracing
- Instantiate `EvaluateQualityModel` with an explicit `system_message` keyword

## Validation
- `uv run python -c "import weave; print(weave.__version__, hasattr(weave, 'type'), hasattr(weave, 'op'), hasattr(weave, 'Model'))"`
- `uv run python -m py_compile openui/eval/evaluate.py openui/eval/model.py openui/eval/evaluate_weave.py openui/eval/promptsearch.py`
- `uv run python -c "from openui.eval.evaluate import EvaluateQualityModel, model; from openui.eval.model import EvaluateQualityModel as LegacyEvaluateQualityModel; print(type(model).__name__)"`
- `git diff --check`