### PR TITLE
chore(security): enable Renovate for GitHub Actions SHA pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>wandb/renovate-config"]
+}


### PR DESCRIPTION
## Summary

This opts the repo into the centralized WandB Renovate setup for GitHub Actions SHA pinning.

- Adds a root `.github/renovate.json5` extending `github>wandb/renovate-config`
- Leaves the existing nested `frontend/.github/renovate.json` unchanged

## Why

The existing Renovate config is nested under `frontend/.github/renovate.json`, so this adds the standard repo-level opt-in used by the centralized WandB Renovate runner for GitHub Actions SHA pinning.

After this merges and the centralized Renovate workflow runs, Renovate should open a follow-up PR pinning this repo's GitHub Actions `uses:` references to commit SHAs.
