### PR TITLE
Add RepoCloud one-click deploy button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ OpenUI let's you describe UI using your imagination, then see it rendered live. 
 
 [Try the demo](https://openui.fly.dev)
 
+## Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/OpenUI/)
+
 ## Running Locally
 
 OpenUI supports [OpenAI](https://platform.openai.com/api-keys), [Groq](https://console.groq.com/keys), and any model [LiteLLM](https://docs.litellm.ai/docs/) supports such as [Gemini](https://aistudio.google.com/app/apikey) or [Anthropic (Claude)](https://console.anthropic.com/settings/keys).  The following environment variables are optional, but need to be set in your environment for alternative models to work:


### PR DESCRIPTION
## Summary

Adds a "Deploy" section to the README with a one-click deploy button linking to [RepoCloud](https://repocloud.io/details/OpenUI/), where OpenUI is available as a managed deployment.

## Changes

- Added a new `## Deploy` section between Live Demo and Running Locally
- Uses the same markdown image link format as the existing Gitpod button (no explicit height, SVG renders at natural size)

## Why

RepoCloud offers managed hosting for open-source applications. This gives users an easy one-click option to deploy their own OpenUI instance without configuring Docker, API keys, or local environments.

## Notes

- Button format matches the existing Gitpod deploy button convention in this README (SVG image, no height attribute)
- Placement follows the natural flow: Live Demo → Deploy your own → Running Locally